### PR TITLE
Implement member rank-up system based on cumulative purchase amount

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,6 +9,7 @@
 .env
 .env.backup
 .env.production
+.env.testing
 .phpactor.json
 .phpunit.result.cache
 Homestead.json

--- a/src/app/Enums/PayBackPoints.php
+++ b/src/app/Enums/PayBackPoints.php
@@ -15,4 +15,19 @@ enum PayBackPoints: string
             self::Gold => 0.1,
         };
     }
+
+    /**
+     * 累計購入額に対応するランクを返す
+     * Bronze: ¥0     〜 ¥9,999
+     * Silver: ¥10,000 〜 ¥49,999
+     * Gold:   ¥50,000 以上
+     */
+    public static function fromTotalAmount(int $totalAmount): self
+    {
+        return match (true) {
+            $totalAmount >= 50000 => self::Gold,
+            $totalAmount >= 10000 => self::Silver,
+            default               => self::Bronze,
+        };
+    }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -22,6 +22,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'member_rank',
+        'total_purchase_amount',
     ];
 
     /**
@@ -48,6 +50,7 @@ class User extends Authenticatable
     }
 
     protected $casts = [
-        'member_rank' => PayBackPoints::class,
+        'member_rank'           => PayBackPoints::class,
+        'total_purchase_amount' => 'integer',
     ];
 }

--- a/src/app/Services/RankUpService.php
+++ b/src/app/Services/RankUpService.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Services;
+
+use App\Enums\PayBackPoints;
+use App\Models\User;
+
+class RankUpService
+{
+    /**
+     * 購入額を累計に加算し、ランクを自動更新する
+     *
+     * @param User $user      対象ユーザー
+     * @param int  $amount    今回の購入額（円）
+     * @return bool           ランクアップが発生した場合 true
+     */
+    public function addPurchaseAndUpdateRank(User $user, int $amount): bool
+    {
+        $previousRank = $user->member_rank;
+
+        $user->total_purchase_amount += $amount;
+        $user->member_rank = PayBackPoints::fromTotalAmount($user->total_purchase_amount);
+        $user->save();
+
+        return $user->member_rank !== $previousRank;
+    }
+}

--- a/src/database/migrations/2026_02_20_000000_add_total_purchase_amount_to_users_table.php
+++ b/src/database/migrations/2026_02_20_000000_add_total_purchase_amount_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('total_purchase_amount')
+                ->default(0)
+                ->comment('累計購入額（円）')
+                ->after('member_rank');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('total_purchase_amount');
+        });
+    }
+};

--- a/src/tests/Feature/RankUpServiceTest.php
+++ b/src/tests/Feature/RankUpServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PayBackPoints;
+use App\Models\User;
+use App\Services\RankUpService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use Tests\TestCase;
+
+final class RankUpServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private RankUpService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RankUpService();
+    }
+
+    #[Test]
+    #[Group('rank')]
+    #[TestDox('累計購入額が¥10,000に達するとBronzeからSilverへランクアップする')]
+    public function it_ranks_up_from_bronze_to_silver_at_10000(): void
+    {
+        $user = User::factory()->create([
+            'member_rank'           => PayBackPoints::Bronze,
+            'total_purchase_amount' => 9000,
+        ]);
+
+        $ranked = $this->service->addPurchaseAndUpdateRank($user, 1000);
+
+        $this->assertTrue($ranked);
+        $this->assertEquals(PayBackPoints::Silver, $user->fresh()->member_rank);
+        $this->assertEquals(10000, $user->fresh()->total_purchase_amount);
+    }
+
+    #[Test]
+    #[Group('rank')]
+    #[TestDox('累計購入額が¥50,000に達するとSilverからGoldへランクアップする')]
+    public function it_ranks_up_from_silver_to_gold_at_50000(): void
+    {
+        $user = User::factory()->create([
+            'member_rank'           => PayBackPoints::Silver,
+            'total_purchase_amount' => 45000,
+        ]);
+
+        $ranked = $this->service->addPurchaseAndUpdateRank($user, 5000);
+
+        $this->assertTrue($ranked);
+        $this->assertEquals(PayBackPoints::Gold, $user->fresh()->member_rank);
+        $this->assertEquals(50000, $user->fresh()->total_purchase_amount);
+    }
+
+    #[Test]
+    #[Group('rank')]
+    #[TestDox('累計購入額が閾値未満の場合はランクアップしない')]
+    public function it_does_not_rank_up_below_threshold(): void
+    {
+        $user = User::factory()->create([
+            'member_rank'           => PayBackPoints::Bronze,
+            'total_purchase_amount' => 0,
+        ]);
+
+        $ranked = $this->service->addPurchaseAndUpdateRank($user, 5000);
+
+        $this->assertFalse($ranked);
+        $this->assertEquals(PayBackPoints::Bronze, $user->fresh()->member_rank);
+        $this->assertEquals(5000, $user->fresh()->total_purchase_amount);
+    }
+
+    #[Test]
+    #[Group('rank')]
+    #[TestDox('Goldランクのユーザーは購入後もGoldのままで戻り値はfalse')]
+    public function it_stays_gold_and_returns_false_for_gold_user(): void
+    {
+        $user = User::factory()->create([
+            'member_rank'           => PayBackPoints::Gold,
+            'total_purchase_amount' => 100000,
+        ]);
+
+        $ranked = $this->service->addPurchaseAndUpdateRank($user, 10000);
+
+        $this->assertFalse($ranked);
+        $this->assertEquals(PayBackPoints::Gold, $user->fresh()->member_rank);
+        $this->assertEquals(110000, $user->fresh()->total_purchase_amount);
+    }
+
+    #[Test]
+    #[Group('rank')]
+    #[TestDox('複数回購入を重ねてBronzeからGoldへランクアップできる')]
+    public function it_can_rank_up_from_bronze_to_gold_via_multiple_purchases(): void
+    {
+        $user = User::factory()->create([
+            'member_rank'           => PayBackPoints::Bronze,
+            'total_purchase_amount' => 0,
+        ]);
+
+        $this->service->addPurchaseAndUpdateRank($user, 10000); // → Silver
+        $user->refresh();
+        $this->assertEquals(PayBackPoints::Silver, $user->member_rank);
+
+        $this->service->addPurchaseAndUpdateRank($user, 40000); // → Gold
+        $user->refresh();
+        $this->assertEquals(PayBackPoints::Gold, $user->member_rank);
+        $this->assertEquals(50000, $user->total_purchase_amount);
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces an automatic member rank-up system that upgrades users through three tiers (Bronze → Silver → Gold) based on their cumulative purchase amount.

## Key Changes
- **Added `RankUpService`**: New service class that handles purchase amount accumulation and automatic rank updates
  - `addPurchaseAndUpdateRank()` method adds purchase amount to user's total and updates rank accordingly
  - Returns boolean indicating whether a rank-up occurred

- **Extended `PayBackPoints` enum**: Added `fromTotalAmount()` static method to determine rank based on cumulative purchases
  - Bronze: ¥0 - ¥9,999
  - Silver: ¥10,000 - ¥49,999
  - Gold: ¥50,000+

- **Database migration**: Added `total_purchase_amount` column to users table
  - Unsigned big integer with default value of 0
  - Stores cumulative purchase amount in yen

- **Updated `User` model**: 
  - Added `member_rank` and `total_purchase_amount` to fillable attributes
  - Added type casting for `total_purchase_amount` as integer

- **Comprehensive test suite**: Added 5 feature tests covering:
  - Bronze to Silver rank-up at ¥10,000
  - Silver to Gold rank-up at ¥50,000
  - No rank-up below thresholds
  - Gold rank stability (no further upgrades)
  - Multi-step rank progression (Bronze → Silver → Gold)

## Implementation Details
- The rank-up logic uses a match expression for clean, readable threshold checking
- Service returns a boolean to indicate rank changes, useful for notifications or logging
- Tests use PHPUnit attributes for better organization and documentation
- Added `.env.testing` to `.gitignore` for test environment configuration

https://claude.ai/code/session_01RkDsXX37rMAVDmFk165Ry9